### PR TITLE
Fix : hotfix (#31)

### DIFF
--- a/src/components/ModifyBoard/index.tsx
+++ b/src/components/ModifyBoard/index.tsx
@@ -69,6 +69,18 @@ const ModifyBoard = (post: PostDetail) => {
     if (newPost.content.length === 0) {
       return alert("내용을 입력해주세요 !");
     }
+    if (newPost.keywords.length === 0) {
+      return alert("키워드를 입력해주세요 !");
+    }
+    if (newPost.category === "") {
+      return alert("카테고리를 선택해주세요 !");
+    }
+    if (newPost.modifyPermission === "") {
+      return alert("수정권한을 선택해주세요 !");
+    }
+    if (newPost.readablePosition === "") {
+      return alert("읽기권한을 선택해주세요 !");
+    }
     updateEditingStatus(post.id);
     editPost({ postId: post.id, post: newPost });
     navigate("/main");

--- a/src/components/WriteBoard/index.tsx
+++ b/src/components/WriteBoard/index.tsx
@@ -55,6 +55,18 @@ const WriteBoard = () => {
     if (newPost.content.length === 0) {
       return alert("내용을 입력해주세요 !");
     }
+    if (newPost.keywords.length === 0) {
+      return alert("키워드를 입력해주세요 !");
+    }
+    if (newPost.category === "") {
+      return alert("카테고리를 선택해주세요 !");
+    }
+    if (newPost.modifyPermission === "") {
+      return alert("수정권한을 선택해주세요 !");
+    }
+    if (newPost.readablePosition === "") {
+      return alert("읽기권한을 선택해주세요 !");
+    }
     addPost(newPost);
     navigate("/main");
   };


### PR DESCRIPTION
### PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치

feat/signup-> develop

### 변경 사항

- 기존 username만 따로 가져가던 형태에서 관계를 매핑하여 User 객체를 통째로 참조하도록 변경
- 게시글, 댓글 모두 수정/삭제 시 username과 일치하는게 아닌 userId와 일치하는 값을 조회

### 테스트 결과

Postman 테스트 결과 이상 없습니다.
