### PR TITLE
Fix : hotfix (#31)

### DIFF
--- a/src/components/BookmarksBoard/index.tsx
+++ b/src/components/BookmarksBoard/index.tsx
@@ -79,7 +79,7 @@ const BookmarksBoard = ({ open, setOpen, postId, folders }: Props) => {
           className={open ? "on" : "off"}
         >
           <StSettingTop>
-            <StSettingTitle>즐겨찾기 추가</StSettingTitle>
+            <StSettingTitle>즐겨찾기</StSettingTitle>
             {setOpen && <StIoClose onClick={() => setOpen("")} />}
           </StSettingTop>
 

--- a/src/routes/Bookmark.tsx
+++ b/src/routes/Bookmark.tsx
@@ -29,6 +29,7 @@ const Bookmark = () => {
 
   const navigate = useNavigate();
   const location = useLocation();
+  const [folderId, setFolderId] = useState<number>(0);
 
   const { mutate: getBookmarks } = useMutation(BOOKMARK.getBookmarks, {
     onSuccess: (res) => {
@@ -45,6 +46,7 @@ const Bookmark = () => {
       });
       setNavItems(nav);
     },
+    onError: () => setNavItems([]),
   });
 
   const { mutate: getBookmark } = useMutation(BOOKMARK.getBookmark, {
@@ -74,25 +76,32 @@ const Bookmark = () => {
 
   const handleEditSubmit = () => {
     editBookmark({
-      folderId: location.state.folderId,
+      folderId,
       bookMarkFolderName: editedFolderName,
     });
     navigate(`/bookmark/${editedFolderName}`);
     handleClickEditBtn();
+    setAddInput("");
   };
 
   const handleClickDelBtn = () => {
-    deleteBookmark(location.state.folderId);
+    deleteBookmark(folderId);
     navigate("/bookmark");
     handleClickEditBtn();
+    setAddInput("");
   };
 
   useEffect(() => {
     setEndPage(1);
     getBookmarks();
     params.folderName
-      ? getBookmark({ folderId: location.state.folderId, page: 1 })
+      ? getBookmark({ folderId, page: 1 })
       : setSearchedPosts([]);
+
+    return () => {
+      setAddInput("");
+      setEditedFolderName("");
+    };
     //eslint-disable-next-line
   }, []);
 
@@ -102,6 +111,11 @@ const Bookmark = () => {
     }
     //eslint-disable-next-line
   }, [params]);
+
+  useEffect(() => {
+    const folId = location?.state?.folderId;
+    setFolderId(folId ? folId : 0);
+  }, [location.state]);
 
   return (
     <>


### PR DESCRIPTION
### PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치

feat/signup-> develop

### 변경 사항

- 기존 username만 따로 가져가던 형태에서 관계를 매핑하여 User 객체를 통째로 참조하도록 변경
- 게시글, 댓글 모두 수정/삭제 시 username과 일치하는게 아닌 userId와 일치하는 값을 조회

### 테스트 결과

Postman 테스트 결과 이상 없습니다.
